### PR TITLE
Add support for 'numeric' PG type

### DIFF
--- a/groundhog-postgresql/groundhog-postgresql.cabal
+++ b/groundhog-postgresql/groundhog-postgresql.cabal
@@ -29,6 +29,7 @@ library
                    , attoparsec               >= 0.8.5.3
                    , resource-pool            >= 0.2.1
                    , time                     >= 1.1
+                   , scientific
     exposed-modules: Database.Groundhog.Postgresql
                      Database.Groundhog.Postgresql.Array
                      Database.Groundhog.Postgresql.Geometry


### PR DESCRIPTION
PostgreSQL's `numeric` type is an "infinite" precision floating point number. It's analogue in Haskell is `Scientific` (used by aeson, cassava, and postgresql-simple for this purpose). I did not pin the version for scientific because it's not pinned by postgresql-simple either. This, of course, introduces an orphan instance. Please provide feedback.